### PR TITLE
A few updates on confs & python

### DIFF
--- a/data/hci.yaml
+++ b/data/hci.yaml
@@ -3,3 +3,6 @@ conferences:
   - title: "CHI: Conference on Human Factors in Computing Systems"
     url: http://chi2016.acm.org/
     date: 2016-05-07
+  - title: "UbiComp: International Joint Conference on Pervasive and Ubiquitous Computing"
+    url: http://ubicomp.org/ubicomp2016/
+    date: 2016-09-12

--- a/data/mobile-computing.yaml
+++ b/data/mobile-computing.yaml
@@ -8,4 +8,5 @@ conferences:
     date: 2016-06-26
   - title: MobiCom
     url: http://www.sigmobile.org/mobicom/
-    date: 2015-09-06
+    date: 2016-10-03 
+

--- a/data/networking.yaml
+++ b/data/networking.yaml
@@ -6,3 +6,6 @@ conferences:
   - title: "NSDI: Networked Systems Design and Implementation"
     url: https://www.usenix.org/conference/nsdi16
     date: 2016-03-16
+  - title: "IMC: Internet Measurement Conference"
+    url: https://conferences.sigcomm.org/imc/2016
+    date: 2016-11-14

--- a/report.py
+++ b/report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import argparse
 import datetime as dt


### PR DESCRIPTION
Added confs: IMC, UbiComp. Updated conf: MobiCom. Updated python version. 

IMC is in Networking 
UbiComp is in HCI
MobiCom, of course, is in Mobile Computing. 

It's better to use "python" rather than "python3" as it works perfectly fine with python2.x. 

Another thoughts: why don't we include "deadline"s ? I think it might  be more helpful . 
